### PR TITLE
Set line length to 99 for .py files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,7 @@ insert_final_newline = true
 # python files
 [*.py]
 trim_trailing_whitespace = true
+max_line_length = 99  # Match line length used by ruff in pyproject.toml
 
 # config files
 [*.{json,json5,yaml,yml,toml}]


### PR DESCRIPTION
This matches the value defined for ruff in the pyproject.toml file